### PR TITLE
Fix interaction of postdeploy and release phase

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
 web: bundle exec puma -C config/puma.rb
+release: ./bin/heroku_release

--- a/app.json
+++ b/app.json
@@ -2,5 +2,11 @@
   "name": "goodreads-quotes",
   "scripts": {
     "postdeploy": "bundle exec rake db:migrate db:seed"
-  }
+  },
+  "addons": ["heroku-postgresql"],
+  "buildpacks": [
+    {
+      "url": "heroku/ruby"
+    }
+  ],
 }

--- a/bin/heroku_release
+++ b/bin/heroku_release
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+#
+# Usage: bin/heroku_deploy
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+NO_COLOR='\033[0m'
+CLEAR_LINE='\r\033[K'
+
+set -euo pipefail
+
+schema_version=$(
+  ./bin/rails db:version |\
+  { grep "^Current version: [0-9]\\+$" || true; } |\
+  tr -s ' ' |\
+  cut -d ' ' -f3
+)
+
+if [ -z "$schema_version" ]; then
+  printf "${RED}   [Release Phase]: Database schema version could not be determined. Does the database exist?${NO_COLOR}\n"
+  exit 1
+fi
+
+if [ "$schema_version" -eq "0" ]; then
+  printf "\n${YELLOW}   [Release Phase]: Loading the database schema.${NO_COLOR}\n"
+  ./bin/rails db:schema:load
+else
+  printf "\n${YELLOW}   [Release Phase]: Running database migrations.${NO_COLOR}\n"
+  ./bin/rails db:migrate
+fi
+
+printf "\n${GREEN}   [Release Phase]: Database is up to date.${NO_COLOR}\n"


### PR DESCRIPTION
In order to get automatic database migrations on deployments, we run a
migration command in the release command in the Procfile.

However, the postdeploy command runs *after* the release command, so PR
apps didn't get a working database before the migrations ran, and the
migrations failed.

This uses a script taken from [1] to run either db:migrate or
schema:load depending on the current database state.

1. https://gist.github.com/stevenharman/98576bf49b050b9e59fb26626b7cceff